### PR TITLE
Tag, you're it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0.0.rc1'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 
-gem 'pry', '~> 0.12.2'
+gem 'pry-rails', '~> 0.3'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'puma', '~> 3.11'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
+
+gem 'acts-as-taggable-on', git: 'https://github.com/mbleigh/acts-as-taggable-on.git'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'devise-jwt', '~> 0.5.9'
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 3.11'
 
 # Reduces boot times through caching; required in config/boot.rb
 
-gem 'acts-as-taggable-on', git: 'https://github.com/mbleigh/acts-as-taggable-on.git'
+gem 'acts-as-taggable-on', git: 'https://github.com/spark-solutions/acts-as-taggable-on.git', branch: 'fix/rails-6-and-failing-specs'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'devise-jwt', '~> 0.5.9'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/mbleigh/acts-as-taggable-on.git
+  revision: fbf2b609b69a90edcd5813e9ba6395a7e293e977
+  specs:
+    acts-as-taggable-on (6.0.1)
+      activerecord (>= 5.0, < 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -256,6 +263,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on!
   bootsnap (>= 1.4.2)
   byebug
   devise-jwt (~> 0.5.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/mbleigh/acts-as-taggable-on.git
-  revision: fbf2b609b69a90edcd5813e9ba6395a7e293e977
+  remote: https://github.com/spark-solutions/acts-as-taggable-on.git
+  revision: 22efcaca0e90a0f2999e5262f7fe1f633d89943a
+  branch: fix/rails-6-and-failing-specs
   specs:
     acts-as-taggable-on (6.0.1)
       activerecord (>= 5.0, < 6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (3.1.0)
     puma (3.12.1)
     rack (2.0.7)
@@ -271,7 +273,7 @@ DEPENDENCIES
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
-  pry (~> 0.12.2)
+  pry-rails (~> 0.3)
   puma (~> 3.11)
   rails (~> 6.0.0.rc1)
   reek (~> 5.4.0)

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -46,6 +46,6 @@ class CreatorsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def creator_params
-      params.require(:creator).permit(:name)
+      params.require(:creator).permit(:name, :genere_list)
     end
 end

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -46,6 +46,6 @@ class CreatorsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def creator_params
-      params.require(:creator).permit(:name, :genere_list)
+      params.require(:creator).permit(:name, :genre_list)
     end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -46,6 +46,10 @@ class WorksController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def work_params
-      params.require(:work).permit(:title, :publish_date)
+      params.require(:work).permit(:title,
+                                   :publish_date,
+                                   :genere_list,
+                                   :contenet_warning_list,
+                                   :theme_list)
     end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -48,8 +48,8 @@ class WorksController < ApplicationController
     def work_params
       params.require(:work).permit(:title,
                                    :publish_date,
-                                   :genere_list,
-                                   :contenet_warning_list,
+                                   :genre_list,
+                                   :content_warning_list,
                                    :theme_list)
     end
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -1,4 +1,6 @@
 class Creator < ApplicationRecord
+  acts_as_taggable_on :genres
+
   has_many :work_creators, dependent: :destroy
   has_many :works, through: :work_creators
   has_many :reviews, through: :works

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,4 +1,6 @@
 class Work < ApplicationRecord
+  acts_as_taggable_on :genres, :content_warnings, :themes
+
   belongs_to :contributor, class_name: 'User'
   belongs_to :work_type
 

--- a/db/migrate/20190630184950_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184950_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20190630184951_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184951_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20190630184952_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184952_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20190630184953_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184953_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20190630184954_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184954_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20190630184955_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190630184955_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_28_032844) do
+ActiveRecord::Schema.define(version: 2019_06_30_184955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,33 @@ ActiveRecord::Schema.define(version: 2019_06_28_032844) do
     t.index ["work_id"], name: "index_reviews_on_work_id"
   end
 
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "username"
     t.string "name"
@@ -176,6 +203,7 @@ ActiveRecord::Schema.define(version: 2019_06_28_032844) do
   add_foreign_key "interest_list_works", "works"
   add_foreign_key "interest_lists", "users"
   add_foreign_key "reviews", "users"
+  add_foreign_key "taggings", "tags"
   add_foreign_key "work_creators", "creators"
   add_foreign_key "work_creators", "works"
   add_foreign_key "works", "users", column: "contributor_id"


### PR DESCRIPTION
Implements tags with [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on).

I looked around to see if there were other promising tagging libraries, including [gutentag](https://github.com/pat/gutentag).

In the end I decided that despite some downsides, I like the robustness of this ~CLI application~ library.

It's a lil' janky -- this branch is pointing to a forked branch that implements some Rails 6 fixes. I think more ideally we'll fork that fork and point to that.